### PR TITLE
Agora é possível abrir os links da página grupos em uma nova aba.

### DIFF
--- a/public/groups.html
+++ b/public/groups.html
@@ -52,8 +52,8 @@
             <div class="container">
                 <ul>
                     <li>
-                        <a href="https://t.co/MpftX2q6He?amp=1">
-                            <img src="https://cdn1.telesco.pe/file/j863aB1QpuqSp9-yLV0vn-CSVLqIMxh4FhyDbMSa6Pg1bEMa63ZpEtYn7ikKLAVpcDlSQmtezn7DdbNYIqgHBUHu-M4hbmylEnu6gDsHG_xCY4hSUnGOUXIymm3trXYYB6hM477I6W0HcdbhB3hP48oAk_bCMLBjtu2nPx_kkVMI-q9NJsjSBwtUUbLha2HseMXVv8rVcNHpVZZPa2K73BXmalJocOyzzAU1KQ5Vw9YZDWVpDfwC8lu_FVme7Pls1vjg9FLMD-AXvQjA4Nk2zqbvyPMEwjVNmoLTSF4qiiyDJyXlRZa_5ikoCQnmyk3-aSFW4Bqgy2WuE_0byInWSg.jpg"
+                        <a href="https://t.co/MpftX2q6He?amp=1" target="_blank">
+                            <img src="https://cdn1.telesco.pe/file/vLoLAdgdlbOlo8uko34bLOS_j0fJROvRnlc7upLz7fp0slKXVpgr3ToDGdM0I-liGSaAG3ah_FtCsl43tGoF_39t5D_1bmTiMdKPpTdYlJ6aabjsyjh3W3HtQcnX4hfLHlsyRF6pA7Il7OzcsMbYayTKVHBewbPEVkWEWxbML34bYsfUWFBnW8esdpGczdTdZpsGF5sUoojfKR4idK3yT_TVI9VYctC1S8M7xJvdHxfnOwlUfrzHmmqETnvDvq3bhox0wz8qWWadY9sCGR_A2-Xxg_u92MGMBUY7bHqRydj78QeI2DWO9GovRgftX4ITXF7k8nbSMyMaJz0S_6e9Pg.jpg"
                             alt="Mulheres na computação">
                             <figcaption>Mulheres na computação</figcaption>
                         </a>
@@ -77,56 +77,56 @@
             <div class="container">
                 <ul>
                     <li>
-                        <a href="https://twitter.com/devsjavagirl">
+                        <a href="https://twitter.com/devsjavagirl" target="_blank">
                             <img src="https://pbs.twimg.com/profile_images/1268221909654740992/vRz7ydTM_400x400.jpg"
                             alt="Devs JavaGirl">
                             <figcaption>Devs JavaGirl</figcaption>
                         </a>
                     </li>
                     <li>
-                        <a href="https://twitter.com/MulheresProduto">
+                        <a href="https://twitter.com/MulheresProduto" target="_blank">
                             <img src="https://pbs.twimg.com/profile_images/1007674012091273221/JmXVZbnJ_400x400.jpg"
                             alt="Mulheres de Protudo">
                             <figcaption>Mulheres de Protudo</figcaption>
                         </a>
                     </li>
                     <li>
-                        <a href="https://twitter.com/beerandcodeyt">
+                        <a href="https://twitter.com/beerandcodeyt" target="_blank">
                             <img src="https://pbs.twimg.com/profile_images/1387313359914250241/JK-_NNHV_400x400.jpg"
                             alt="Beer and Code">
                             <figcaption>Beer and Code</figcaption>
                         </a>
                     </li>
                     <li>
-                        <a href="https://twitter.com/feminis_tech">
+                        <a href="https://twitter.com/feminis_tech" target="_blank">
                             <img src="https://pbs.twimg.com/profile_images/1403804873087459334/v-S9q_i4_400x400.jpg"
                             alt="Feministech">
                             <figcaption>Feministech</figcaption>
                         </a>
                     </li>
                     <li>
-                        <a href="https://twitter.com/PyLadiesBrasil">
+                        <a href="https://twitter.com/PyLadiesBrasil" target="_blank">
                             <img src="https://pbs.twimg.com/profile_images/1150461616523227137/ANsmViBz_400x400.jpg"
                             alt="PyLadies Brasil">
                             <figcaption>PyLadies Brasil</figcaption>
                         </a>
                     </li>
                     <li>
-                        <a href="https://twitter.com/minasprogramam">
+                        <a href="https://twitter.com/minasprogramam" target="_blank">
                             <img src="https://pbs.twimg.com/profile_images/1155084673439191040/rxpoJlT9_400x400.png"
                             alt="Minas Programam">
                             <figcaption>minas programam</figcaption>
                         </a>
                     </li>
                     <li>
-                        <a href="https://twitter.com/CloudgirlsIn">
+                        <a href="https://twitter.com/CloudgirlsIn" target="_blank">
                             <img src="https://pbs.twimg.com/profile_images/1157633788240961537/fgGy14K0_400x400.jpg"
                             alt="Cloud Girls">
                             <figcaption>Cloud Girls</figcaption>
                         </a>
                     </li>
                     <li>
-                        <a href="https://twitter.com/_testgirls">
+                        <a href="https://twitter.com/_testgirls" target="_blank">
                             <img src="https://pbs.twimg.com/profile_images/1164931027229392896/59yO01ST_400x400.jpg"
                             alt="Cloud Girls">
                             <figcaption>Test Girls</figcaption>

--- a/public/index.html
+++ b/public/index.html
@@ -50,7 +50,7 @@
         <main id="banner">
             <div id="banner__left">
                 <h1>Nossa missão é te ajudar!</h1>
-                <p>Aqui você vai encontrar grupos, cursos e outros ajudas para seus estudos.</p>
+                <p>Aqui você vai encontrar grupos, cursos e outras ajudas para seus estudos.</p>
             </div>
             <div id="banner__right">
                 <lottie-player id="animation" src="https://assets8.lottiefiles.com/packages/lf20_gzl797gs.json"


### PR DESCRIPTION
**Corrigi o link source da imagem do item mulheres na computação, a imagem não estava aparecendo.**
![Captura de tela de 2021-07-13 18-08-11](https://user-images.githubusercontent.com/50778163/125525223-0f0ed3c5-aedf-4a76-b2d7-dbb8dcfbfb6a.png)

**Corrigi o texto na pela inicial, o trecho "cursos e outros ajudas ..." não faz muito sentido.**
![Captura de tela de 2021-07-13 18-09-31](https://user-images.githubusercontent.com/50778163/125525432-6b2bc3c0-7f93-436a-a462-635ec109ab79.png)


